### PR TITLE
Filter out contracts without contractsets when computing user worth

### DIFF
--- a/client/lib/helpers/global_helpers.coffee
+++ b/client/lib/helpers/global_helpers.coffee
@@ -83,8 +83,14 @@
        .value()
 
   contracts_with_prices: (market_id, live_trade) ->
-    market_contracts = Contracts.find({market_id: market_id}).fetch()
     market_contractsets = Contractsets.find({market_id: market_id}).fetch()
+
+    # Filter contracts for extra security against contracts with deleted
+    # contractset Should not be possible, but it has happened
+    market_contracts = _.filter Contracts.find({market_id: market_id}).fetch(), (contract) ->
+      contract.set_id in _.pluck market_contractsets, "_id"
+
+    console.log market_contracts.length
     unless market_contractsets? and market_contractsets.length > 0
       return []
     if live_trade?
@@ -107,7 +113,6 @@
   compute_wallet: (market_id) ->
     wallet = {}
     portfolio = Meteor.user()?.profile?.portfolio
-    contracts = Contracts.find({market_id: market_id}).fetch()
     market = Markets.findOne {_id: market_id}
     contractsets = _.indexBy Contractsets.find({market_id: market_id}).fetch(), (set) ->
       set._id

--- a/client/routes.coffee
+++ b/client/routes.coffee
@@ -110,7 +110,7 @@ Router.route '/markets/', ->
   @render 'MarketList'
 , {waitOn: ->
      if Meteor?.userId()
-       cols = ['Pages', 'Markets']
+       cols = ['Pages', 'Markets', "Contracts", "Contractsets"]
        _.map cols, (col) ->
          TAPi18n.subscribe col
   }

--- a/client/views/users/market.coffee
+++ b/client/views/users/market.coffee
@@ -39,7 +39,6 @@ Template.Market.helpers
     contracts = Contracts.find({market_id: market_id}).fetch()
     contractsets = Contractsets.find(
         $and: [{market_id: market_id},
-               {active: true},
                {launchtime: {$lte: now}},
                {settletime: {$gte: now}}]
       ,
@@ -117,7 +116,8 @@ Template.Market.helpers
           _.contains word_matches, id
 
     _.filter contractsets, (set) ->
-      return set._id in contractsets_with_portfolio and
+      return set.active is true and
+             set._id in contractsets_with_portfolio and
              set._id in contractsets_closing_soon and
              set._id in contractsets_matching_text_filters
 
@@ -197,7 +197,7 @@ Template.Market.events
     market_id = Router.current().params._id
     set_contract_filter_text market_id, evt
 
-  
+
 Template.Market.rendered = ->
   @autorun ->
     order = Session.get 'order-details'

--- a/server/publications.coffee
+++ b/server/publications.coffee
@@ -18,7 +18,6 @@ TAPi18n.publish "Contractsets", ->
       market_ids = _.map Markets.i18nFind({'tags': {$in: user.profile.tags}}).fetch(), (market) -> market._id
 
       Contractsets.i18nFind
-        # active: true
         settled: false
         market_id: {$in: market_ids}
         launchtime: {$lte: Date.now()}
@@ -33,7 +32,6 @@ TAPi18n.publish "Contracts", ->
     else
       market_ids = _.map Markets.i18nFind({'tags': {$in: user.profile.tags}}).fetch(), (market) -> market._id
       contractset_ids = _.map Contractsets.i18nFind(
-        # active: true
         settled: false
         market_id: {$in: market_ids}
         launchtime: {$lte: Date.now()}


### PR DESCRIPTION
<phew> this bug was a tough nut. Turns out there are inconsistencies in the database. There are 13 contracts whose contractsets are missing. I don't know how that can possibly have happened, but there you go...

This made it so that computing the worth of contracts starting with sets created a different result than when starting with directly with the contracts. Different approaches are used at different places, hence the inconsistent numbers on the page.

I put in a filter that explicitly removes all contracts that have no sets from calculations.

The contracts with missing sets are:

```
Contractset yQgKyfPR3Tc6B4sgX:
> 4pwEfHG2cKWPDtXiW
> 8fuAKqT62fMijoqEm
> Jg3DZbFc6WXoGpbKq
> TisLZoCRTrojf9Rsp
> hovy5XdtcQHp3gpgd
> wdSWtWwqmrPxe9Ada
> z6jBCn2q2R2oycyRE

Contractset hj9i7nf4XaG4ET5iJ:
> E7Gwv5nZXt9im7TRB
> Fq7CfaDQ8BADy8nFH
> LuKTqzzqbJW9FHrmZ
> T8HSJxmyX2GNSLe8q
> qyy3y7r2TTWL2cWFB
> r59EHujR7jczn82LG
```
